### PR TITLE
Thread 왕 변경 개발

### DIFF
--- a/src/main/java/server/drawwang/domain/board/repository/BoardRepository.java
+++ b/src/main/java/server/drawwang/domain/board/repository/BoardRepository.java
@@ -2,6 +2,10 @@ package server.drawwang.domain.board.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import server.drawwang.domain.board.entity.BoardEntity;
+import server.drawwang.domain.thread.entity.ThreadEntity;
+
+import java.util.List;
 
 public interface BoardRepository extends JpaRepository<BoardEntity, Long> {
+    List<BoardEntity> findAllByThread(ThreadEntity thread);
 }

--- a/src/main/java/server/drawwang/domain/thread/controller/ThreadController.java
+++ b/src/main/java/server/drawwang/domain/thread/controller/ThreadController.java
@@ -29,4 +29,10 @@ public class ThreadController {
         List<ToThreadResponse> threads = threadService.getThread();
         return new ResponseEntity<>(new ThreadListResponse(threads), HttpStatus.OK);
     }
+
+    @PutMapping("/{threadId}/king")
+    public ResponseEntity<Void> updateThreadKing(@PathVariable Long threadId) {
+        threadService.updateThreadKing(threadId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/src/main/java/server/drawwang/domain/thread/entity/ThreadEntity.java
+++ b/src/main/java/server/drawwang/domain/thread/entity/ThreadEntity.java
@@ -1,51 +1,15 @@
 package server.drawwang.domain.thread.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalDateTime;
-
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalDateTime;
-
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalDateTime;
-
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalDateTime;
 
 @Entity
-@Getter
+@Getter @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "thread")

--- a/src/main/java/server/drawwang/domain/thread/service/ThreadService.java
+++ b/src/main/java/server/drawwang/domain/thread/service/ThreadService.java
@@ -1,6 +1,5 @@
 package server.drawwang.domain.thread.service;
 
-import server.drawwang.domain.board.entity.ToBoardResponse;
 import server.drawwang.domain.thread.entity.dto.request.CreateThreadRequest;
 import server.drawwang.domain.thread.entity.dto.response.ToThreadResponse;
 
@@ -11,4 +10,5 @@ public interface ThreadService {
 
     List<ToThreadResponse> getThread();
 
+    void updateThreadKing(Long threadId);
 }

--- a/src/main/java/server/drawwang/global/exception/CustomErrorCode.java
+++ b/src/main/java/server/drawwang/global/exception/CustomErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum CustomErrorCode {
 
     //==400==//
+    THREAD_KING_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "쓰레드의 왕이 이미 지정되어 있습니다."),
+    THREAD_NOT_EXPIRED(HttpStatus.BAD_REQUEST, "쓰레드가 만료되지 않았습니다."),
     THREAD_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "쓰레드를 찾을 수 없습니다."),
     BOARD_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다.");
 


### PR DESCRIPTION
#7 

# 💬 개요 💬
- Thread 왕 변경 개발

#  💬 작업 내용 💬

## Thread 왕 변경

httpMethod : `PUT`
endPoint : `/api/thread/{threadId}/king`
<img width="266" alt="화면 캡처 2024-02-13 011743" src="https://github.com/Team-Ampersand/drawWang-Server/assets/132252080/75e24c67-f76a-46d1-9bf5-8ae812e35640">
- like가 가장 많은 board를 king으로 지정합니다.
- 1번 지정된 thread의 king은 변경되지 않습니다.
- thread가 만료되어야 thread의 king을 지정할 수 있습니다.